### PR TITLE
Add initial 2017 stats post.

### DIFF
--- a/moss-final-report.rst
+++ b/moss-final-report.rst
@@ -5,8 +5,8 @@ MOSS Final Report
 =================
 
 Last year,
-we were given a :doc:`MOSS Award <rtd-awarded-mozilla-open-source-support-grant>` to work on improving the Python documentation ecosystem.
-We :doc:`announced <announcing-pydoc-io>` the initial deployment last November,
+we were given a :doc:`MOSS Award </rtd-awarded-mozilla-open-source-support-grant>` to work on improving the Python documentation ecosystem.
+We :doc:`announced </announcing-pydoc-io>` the initial deployment last November,
 and this is the retrospective post about how the project as a whole went.
 
 This work is live at http://www.pydoc.io/ and on GitHub:

--- a/read-the-docs-2017-stats.rst
+++ b/read-the-docs-2017-stats.rst
@@ -4,7 +4,7 @@
 Read the Docs 2017 Stats
 ========================
 
-2017 has been a good year for Read the Docs.
+2017 was a good year for Read the Docs.
 We've settled into a sustainability model that is working for us,
 and have started to grow our team to be able to better support the community.
 
@@ -72,8 +72,6 @@ Funding
 
 * $250,000 in revenue (up from $75,000 in 2016)
 
-Read the Docs is sustainable.
-
 We now have four full-time people working on the project.
 This has made it feel like we're able to move forward,
 instead of simply fighting to stay in the same place.
@@ -97,7 +95,6 @@ because Rackspace is winding down their support for OSS hosting.
 Conclusion
 ----------
 
-2017 has been a good year.
 We have decided to invest in building a sustainable business instead of trying to work only on volunteer effort.
 This has allowed us to focus on things we can control,
 build a small team,

--- a/read-the-docs-2017-stats.rst
+++ b/read-the-docs-2017-stats.rst
@@ -70,7 +70,7 @@ This year, we had:
 Funding
 -------
 
-* $300,000 in revenue (up from $50,000 in 2016)
+* $250,000 in revenue (up from $75,000 in 2016)
 
 Read the Docs is sustainable.
 

--- a/read-the-docs-2017-stats.rst
+++ b/read-the-docs-2017-stats.rst
@@ -1,4 +1,4 @@
-.. post:: Jan 26, 2018
+.. post:: Feb 14, 2018
    :tags: stats, year-in-review
 
 Read the Docs 2017 Stats

--- a/read-the-docs-2017-stats.rst
+++ b/read-the-docs-2017-stats.rst
@@ -8,6 +8,11 @@ Read the Docs 2017 Stats
 We've settled into a sustainability model that is working for us,
 and have started to grow our team to be able to better support the community.
 
+Here are our stats for the past year,
+which we've published for the past 5 years.
+This is part of our effort to be transparent in our organization,
+as well as our source code.
+
 .. note:: 
 
 	You can always see our stats for the last `30 days`_. 

--- a/read-the-docs-2017-stats.rst
+++ b/read-the-docs-2017-stats.rst
@@ -18,7 +18,7 @@ and have started to grow our team to be able to better support the community.
 .. _2013: https://blog.readthedocs.com/read-the-docs-2013-stats/
 .. _2014: https://blog.readthedocs.com/read-the-docs-2014-stats/
 .. _2015: https://blog.readthedocs.com/read-the-docs-2015-stats/
-.. _2015: https://blog.readthedocs.com/read-the-docs-2016-stats/
+.. _2016: https://blog.readthedocs.com/read-the-docs-2016-stats/
 
 Page Views
 ----------
@@ -43,6 +43,13 @@ The stats, in total numbers:
 * 77,000 projects (up from 53k in 2016)
 * 103,000 users (up from 65k in 2016)
 
+We have been battling spam quite heavily this year,
+so these numbers might be a bit skewed.
+I believe they should be pretty accurate in terms of percentage growth though.
+
+.. Project.objects.count()
+.. User.objects.count()
+
 Community
 ---------
 
@@ -56,17 +63,33 @@ This year, we had:
 .. git rev-list --count --all --max-age=1451606400 --min-age=1483228800
 .. is:issue  created:2017-01-01..2017-01-01 
 
+.. _people: https://github.com/rtfd/readthedocs.org/graphs/contributors?from=2017-01-01&to=2017-12-31&type=c
+.. _commits: https://github.com/rtfd/readthedocs.org/commits/master
+.. _issues: https://github.com/rtfd/readthedocs.org/search?utf8=%E2%9C%93&q=created%3A%3E%3D2017-01-01&type=Issues
+
 Funding
 -------
+
+* $300,000 in revenue (up from $50,000 in 2016)
+
+Read the Docs is sustainable.
+
+We now have four full-time people working on the project.
+This has made it feel like we're able to move forward,
+instead of simply fighting to stay in the same place.
+
+Our largest initiative this year has been our `Ethical Advertising`_ initiative.
+It has been going quite well,
+and is the primary driver of our ability to hire a team to work on things.
+
+Our other two funding sources are readthedocs.com & donations.
+Both are bringing in appreciable amounts of money,
+but the advertising is at around 5x the combined value of our other revenue sources.
 
 Our hosting costs continue to be sponsored by `Rackspace`_,
 which is fantastically generous of them.
 We're looking at moving hosting providers in 2018,
 because Rackspace is winding down their support for OSS hosting.
-
-Our largest initiative this year has been our `Ethical Advertising`_ initiative.
-It has been going well,
-and allowed us to start building a team of 4 people to work on Read the Docs starting in 2018.
 
 .. _Rackspace: http://rackspace.com/
 .. _Ethical Advertising: http://docs.readthedocs.io/en/latest/ethical-advertising.html
@@ -80,8 +103,7 @@ This has allowed us to focus on things we can control,
 build a small team,
 and help improve the product for all of our users.
 
+We look forward to continuing to grow into 2018!
+
 .. _Read the Docs: https://readthedocs.org/
 
-.. _commits: https://github.com/rtfd/readthedocs.org/commits/master
-.. _people: https://github.com/rtfd/readthedocs.org/graphs/contributors?from=2017-01-01&to=2017-12-31&type=c
-.. _issues: https://github.com/rtfd/readthedocs.org/search?utf8=%E2%9C%93&q=created%3A%3E%3D2017-01-01&type=Issues

--- a/read-the-docs-2017-stats.rst
+++ b/read-the-docs-2017-stats.rst
@@ -1,0 +1,87 @@
+.. post:: Jan 26, 2018
+   :tags: stats, year-in-review
+
+Read the Docs 2017 Stats
+========================
+
+2017 has been a good year for Read the Docs.
+We've settled into a sustainability model that is working for us,
+and have started to grow our team to be able to better support the community.
+
+.. note:: 
+
+	You can always see our stats for the last `30 days`_. 
+
+	Our posts from 2013_, 2014_, 2015_, and 2016_ are also available.
+
+.. _30 days: http://www.seethestats.com/site/readthedocs.org
+.. _2013: https://blog.readthedocs.com/read-the-docs-2013-stats/
+.. _2014: https://blog.readthedocs.com/read-the-docs-2014-stats/
+.. _2015: https://blog.readthedocs.com/read-the-docs-2015-stats/
+.. _2015: https://blog.readthedocs.com/read-the-docs-2016-stats/
+
+Page Views
+----------
+
+Our stats:
+
+* 338 Million Page Views (up from 252M in 2016)
+* 75 Million Unique Visitors (up from 56M in 2016)
+
+.. From Google Analytics
+
+We remain one of the `largest sites`_ on the internet.
+Turns out *a lot of people* read documentation each day for open source projects!
+
+.. _largest sites: http://www.alexa.com/siteinfo/readthedocs.io
+
+Site Stats
+----------
+
+The stats, in total numbers:
+
+* 77,000 projects (up from 53k in 2016)
+* 103,000 users (up from 65k in 2016)
+
+Community
+---------
+
+This year, we had:
+
+* 23 `people`_ who committed code to the main repository (up from 18 in 2016)
+* 1058 `commits`_ (similar to 1032 in 2016)
+* 513 `issues`_ - 194 open, 319 closed (up from 461 in 2016)
+
+.. https://github.com/rtfd/readthedocs.org/graphs/contributors?from=2017-01-01&to=2017-12-31&type=c
+.. git rev-list --count --all --max-age=1451606400 --min-age=1483228800
+.. is:issue  created:2017-01-01..2017-01-01 
+
+Funding
+-------
+
+Our hosting costs continue to be sponsored by `Rackspace`_,
+which is fantastically generous of them.
+We're looking at moving hosting providers in 2018,
+because Rackspace is winding down their support for OSS hosting.
+
+Our largest initiative this year has been our `Ethical Advertising`_ initiative.
+It has been going well,
+and allowed us to start building a team of 4 people to work on Read the Docs starting in 2018.
+
+.. _Rackspace: http://rackspace.com/
+.. _Ethical Advertising: http://docs.readthedocs.io/en/latest/ethical-advertising.html
+
+Conclusion
+----------
+
+2017 has been a good year.
+We have decided to invest in building a sustainable business instead of trying to work only on volunteer effort.
+This has allowed us to focus on things we can control,
+build a small team,
+and help improve the product for all of our users.
+
+.. _Read the Docs: https://readthedocs.org/
+
+.. _commits: https://github.com/rtfd/readthedocs.org/commits/master
+.. _people: https://github.com/rtfd/readthedocs.org/graphs/contributors?from=2017-01-01&to=2017-12-31&type=c
+.. _issues: https://github.com/rtfd/readthedocs.org/search?utf8=%E2%9C%93&q=created%3A%3E%3D2017-01-01&type=Issues

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Werkzeug==0.9.6
-ablog==0.8.4
 wsgiref==0.1.2
 Sphinx==1.6.6
+
+# https://github.com/abakan/ablog/pull/93
+git+https://github.com/tadeboro/ablog#egg=ablog-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Werkzeug==0.9.6
-ablog==0.7.12
+ablog==0.8.4
 wsgiref==0.1.2
-Sphinx
+Sphinx==1.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ wsgiref==0.1.2
 Sphinx==1.6.6
 
 # https://github.com/abakan/ablog/pull/93
-git+https://github.com/tadeboro/ablog#egg=ablog-dev
+git+https://github.com/tadeboro/ablog@cc099ccdfac85a4c2f4a64ecf04e17b3019ce5a7#egg=ablog-dev


### PR DESCRIPTION
This removes a lot of the commentary that was standard in prior years,
and just tries to get the stats out.

I don't think many people read the commentary,
so I think just having a history of the stats is better.
We can provide commentary in other formats that people are more likely to read.