### PR TITLE
Login with Version Control announcement

### DIFF
--- a/version-control-login.rst
+++ b/version-control-login.rst
@@ -1,0 +1,43 @@
+.. post:: May 9, 2018
+   :tags: feature, new-user, versioncontrol
+   :author: David
+   :location: SAN
+
+
+Version Control Log in
+======================
+
+Today we are announcing the ability to log in or sign up to Read the Docs
+with your favorite version control hosting services like GitHub, BitBucket, or GitLab.
+This was one of our most requested features and
+it has been something we've been meaning to launch for a long time.
+
+
+For new Read the Docs users
+---------------------------
+
+For new users, the sign up process is significantly streamlined.
+There's no new password to remember and when you're ready to start building your docs,
+Read the Docs will be ready with a list of your repositories to get started.
+
+Click the "sign up" button on the Read the Docs home page and then click
+the button for your favorite version control host.
+
+
+For existing Read the Docs users
+--------------------------------
+
+If you've already connected your GitHub, BitBucket or GitLab account,
+you can use it to log in with Read the Docs instead of your password.
+If you haven't connected your account previously,
+you will have to log in normally and connect your account to use it to log in.
+
+You can always see and manage which accounts you have connected
+`in your profile`_ (log in required).
+
+.. _in your profile: https://readthedocs.org/accounts/social/connections/
+
+As always, if you notice anything strange with your build,
+feel free to raise an issue on our `issue tracker`_.
+
+.. _issue tracker: https://github.com/rtfd/readthedocs.org/issues

--- a/version-control-login.rst
+++ b/version-control-login.rst
@@ -1,4 +1,4 @@
-.. post:: May 9, 2018
+.. post:: May 17, 2018
    :tags: feature, new-user, versioncontrol
    :author: David
    :location: SAN

--- a/version-control-login.rst
+++ b/version-control-login.rst
@@ -4,8 +4,8 @@
    :location: SAN
 
 
-Version Control Log in
-======================
+Social Version Control Log in
+=============================
 
 Today we are announcing the ability to log in or sign up to Read the Docs
 with your favorite version control hosting services like GitHub, BitBucket, or GitLab.
@@ -20,8 +20,8 @@ For new users, the sign up process is significantly streamlined.
 There's no new password to remember and when you're ready to start building your docs,
 Read the Docs will be ready with a list of your repositories to get started.
 
-Click the "sign up" button on the Read the Docs home page and then click
-the button for your favorite version control host.
+Click the "Sign Up" button on the Read the Docs home page and then click
+the button for your favorite version control hosting service.
 
 
 For existing Read the Docs users


### PR DESCRIPTION
This is a pretty short blog but it should make for a good announcement. I'm aiming for a week from today which is between WTD and PyCon.

This feature was added here: https://github.com/rtfd/readthedocs.org/pull/4022.

I considered putting an image (either static or an animated gif) but I don't think it is necessary. An image of the login screen has a lot of stuff that isn't "log in with ..." related.