### PR TITLE
Write an atom feed resolving relative links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build
 *.sw[opmn]
+*.pyc
 .python-version
 .ropeproject/

--- a/conf.py
+++ b/conf.py
@@ -20,6 +20,7 @@ import ablog
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
+sys.path.append(os.path.abspath('exts'))
 
 # -- General configuration ------------------------------------------------
 
@@ -32,10 +33,11 @@ import ablog
 extensions = [
     'ablog',
     'sphinx.ext.intersphinx',
+    'atom_absolute',
 ]
 
 blog_title = 'Read the Docs Blog'
-blog_baseurl = 'http://blog.readthedocs.com'
+blog_baseurl = 'https://blog.readthedocs.com'
 blog_path = 'archive'
 fontawesome_link_cdn = 'https://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css'
 # fontawesome_included = True

--- a/exts/atom_absolute.py
+++ b/exts/atom_absolute.py
@@ -1,0 +1,57 @@
+from __future__ import unicode_literals
+
+import os.path
+
+from lxml import etree, html
+from six.moves.urllib.parse import urljoin
+from sphinx.util import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def rewrite_atom_feed(app, exception):
+    """
+    Rewrites the atom feed content elements to use absolute instead of relative links
+
+    Applies to <a> and <img>
+    """
+    if exception:
+        logger.info('Skipping atom feed link rewrite due to errors...')
+    else:
+        logger.info('Rewriting atom feed...')
+
+        feed_path = os.path.join(app.outdir, 'archive/atom.xml')
+        feed_url = urljoin(app.config.blog_baseurl, 'archive/atom.xml')
+        rewritten_feed_path = os.path.join(app.outdir, 'archive/atom_absolute.xml')
+
+        if not os.path.isfile(feed_path):
+            logger.error('Atom feed does not exist at: {}'.format(feed_path))
+            return
+
+        doc = etree.parse(feed_path)
+        root = doc.getroot()
+
+        # Rewrite the namespace map to not be Null
+        namespace = root.nsmap.values()[0]
+        nsmap = {'atom': namespace}
+
+        # Convert the content nodes to use absolute links
+        for content in root.xpath('//atom:entry/atom:content', namespaces=nsmap):
+            html_content = html.fromstring(content.text)
+            html_content.make_links_absolute(feed_url)
+            content.text = html.tostring(html_content)
+
+        with open(rewritten_feed_path, 'w') as fd:
+            doc.write(fd)
+            logger.info('Wrote absolute atom feed to {}'.format(rewritten_feed_path))
+
+
+def setup(app):
+    app.connect('build-finished', rewrite_atom_feed)
+
+    return {
+        'version': 'local',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 Sphinx<1.8>1.7
+six
+
+# Used to rewrite the Atom feed to use absolute links
+lxml==4.2.1
 
 # https://github.com/abakan/ablog/pull/93
 git+https://github.com/tadeboro/ablog@cc099ccdfac85a4c2f4a64ecf04e17b3019ce5a7#egg=ablog-dev


### PR DESCRIPTION
This PR adds a custom sphinx extension which writes a slightly modified atom feed based on the one outputted from ablog. For reasons that are probably bad, the [Mailchimp RSS emailer](https://kb.mailchimp.com/templates/code/common-html-mistakes#Images,-Links,-and-Graphics) doesn't handle relative links or images with a relative URL. Without this change, these automatic emails will have broken links and images.

The resulting new atom feed doesn't replace the old one but instead will live at `/archive/atom_absolute.xml`. It won't be used by users but just from the Mailchimp campaign.

It uses lxml's [`make_links_absolute`](http://lxml.de/lxmlhtml.html#working-with-links) method.

See: https://github.com/sunpy/ablog/issues/19