### PR TITLE
Do not track blog post

### DIFF
--- a/do-not-track.rst
+++ b/do-not-track.rst
@@ -67,8 +67,9 @@ Supporting Do Not Track is an important milestone along the way
 as it confirms our commitment to privacy in advertising.
 We believe that ads don't have to track people to be effective.
 
-Our Ethical Ad network is still in its early stages,
+Our `Ethical Ad network`_ is still in its early stages,
 but if you want to know more or you know a project that could use it, 
 please `get in touch`_.
 
+.. _Ethical Ad network: https://www.ethicalads.io/
 .. _get in touch: mailto:ads@readthedocs.org

--- a/do-not-track.rst
+++ b/do-not-track.rst
@@ -20,28 +20,39 @@ and keeping Read the Docs sustainable.
 .. _guidelines: https://www.eff.org/issues/do-not-track
 
 
+What we implemented
+-------------------
+
+Not much needed to change to make Read the Docs support DNT
+and many of these changes were already necessary
+for the EU's new :doc:`privacy regulation <gdpr-what-it-means-for-readthedocs>`.
+
+Here's a brief list of what we did for Do Not Track:
+
+* Our logs that store any personal data are deleted after no more than ten days.
+  We do this for all users even those who don't have DNT enabled.
+* When a user has DNT enabled, we do not send data to our analytics.
+* While this didn't change, we reiterated that we **do not**
+  do behavioral ad targeting regardless of DNT preference.
+  
+Full details on Do Not Track at Read the Docs can be found in our `privacy policy`_.
+
+.. _privacy policy: https://docs.readthedocs.io/en/latest/privacy-policy.html#privacy-policy-do-not-track
+
+
 What DNT means for our advertising
 ----------------------------------
 
 Advertising at Read the Docs was already built with privacy in mind.
 With our `Ethical Ads`_, we previously committed to not tracking users,
-not selling user data, and hosting ads ourselves.
+not selling user data, and hosting ads ourselves
+which all align perfectly with Do Not Track.
 
-Our support for Do Not Track does not change that.
-Instead, it formalizes our commitment
-to be the same as guidelines produced by the EFF and elsewhere.
-
-At Read the Docs this means:
-
-* We **do not** do behavioral ad targeting regardless of your DNT preference.
-* Our logs that store any personal data are deleted after no more than ten days.
-  We do this for all users even those who don't have DNT enabled.
-* When a user has DNT enabled, we do not send data to our analytics.
-  
-Full details on Do Not Track at Read the Docs can be found in our `privacy policy`_.
+Our support for DNT formalizes our commitment to the high standards
+for privacy produced by the EFF.
+It also make us one of very few ad networks that honor Do Not Track.
 
 .. _Ethical Ads: https://docs.readthedocs.io/en/latest/ethical-advertising.html
-.. _privacy policy: https://docs.readthedocs.io/en/latest/privacy-policy.html#privacy-policy-do-not-track
 
 
 The Ethical Ad Network

--- a/do-not-track.rst
+++ b/do-not-track.rst
@@ -32,6 +32,7 @@ Here's a brief list of what we did for Do Not Track:
 * Our logs that store any personal data are deleted after no more than ten days.
   We do this for all users even those who don't have DNT enabled.
 * When a user has DNT enabled, we do not send data to our analytics.
+  Based on our initial data, this looks like about a 6% reduction.
 * While this didn't change, we reiterated that we **do not**
   do behavioral ad targeting regardless of DNT preference.
   

--- a/do-not-track.rst
+++ b/do-not-track.rst
@@ -1,0 +1,63 @@
+.. post:: June 8, 2018
+   :tags: privacy, advertising
+   :author: David
+   :location: SAN
+
+Do Not Track at Read the Docs
+=============================
+
+Today, we are pleased to announce that Read the Docs honors `Do Not Track`_ (DNT).
+DNT is a browser preference that requests that a user not be tracked
+across the internet while browsing the web.
+
+While there isn't a consensus on precisely what DNT should mean,
+we are following the Electronic Frontier Foundation's (EFF) `guidelines`_
+for Do Not Track as we believe that gives a good balance
+between the privacy expectations of users and the reality of running a business
+and keeping Read the Docs sustainable.
+
+.. _Do Not Track: https://allaboutdnt.com/
+.. _guidelines: https://www.eff.org/issues/do-not-track
+
+
+What DNT means for our advertising
+----------------------------------
+
+Advertising at Read the Docs was already built with privacy in mind.
+With our `Ethical Ads`_, we previously committed to not tracking users,
+not selling user data, and hosting ads ourselves.
+
+Our support for Do Not Track does not change that.
+Instead, it formalizes our commitment
+to be the same as guidelines produced by the EFF and elsewhere.
+
+At Read the Docs this means:
+
+* We **do not** do behavioral ad targeting regardless of your DNT preference.
+* Our logs that store any personal data are deleted after no more than ten days.
+  We do this for all users even those who don't have DNT enabled.
+* When a user has DNT enabled, we do not send data to our analytics.
+  
+Full details on Do Not Track at Read the Docs can be found in our `privacy policy`_.
+
+.. _Ethical Ads: https://docs.readthedocs.io/en/latest/ethical-advertising.html
+.. _privacy policy: https://docs.readthedocs.io/en/latest/privacy-policy.html#privacy-policy-do-not-track
+
+
+The Ethical Ad Network
+----------------------
+
+In a :doc:`previous post <ethical-advertising-works>`,
+we mentioned that we are taking the same developer-centric, privacy-focused
+advertising we have on Read the Docs and expanding this to a larger ad network
+for open source infrastructure.
+
+Supporting Do Not Track is an important milestone along the way
+as it confirms our commitment to privacy in advertising.
+We believe that ads don't have to track people to be effective.
+
+Our Ethical Ad network is still in its early stages,
+but if you want to know more or you know a project that could use it, 
+please `get in touch`_.
+
+.. _get in touch: mailto:ads@readthedocs.org


### PR DESCRIPTION
Initially I'm targeting this post for Friday June 8. If that date slips, it should be ok.

This is a simple announcement blog post publicly discussing DNT. The target audience is RTD users. However, the call to action at the end is for people interested in the ad network.

One thing I'd like to add but don't yet have enough data on is what % of our users have DNT enabled. We will see that by a reduction in analytics pageviews. By Friday there should be enough data.