### PR TITLE
API update blog

### DIFF
--- a/api-v2.rst
+++ b/api-v2.rst
@@ -1,0 +1,44 @@
+.. post:: July 26, 2018
+   :tags: api, feature, reference
+   :author: David
+   :location: SAN
+
+Read the Docs Public API
+========================
+
+Recently, we revamped Read the Docs' public API.
+Previously, our latest API (v2) was used by our build processes
+but not heavily used by outside users.
+
+As part of this process, we put effort into making sure the API is easy to use
+to access Read the Docs *projects*, *builds*, and *versions*
+and that the `documentation`_ is up-to-date.
+
+.. _documentation: https://docs.readthedocs.io/en/latest/api/v2.html
+
+
+Deprecation of API v1 and connecting over insecure HTTP
+-------------------------------------------------------
+
+As part of this process, we are formally deprecating support for our `API v1`_.
+It will be **supported through at least January 1, 2019**
+but we strongly encourage all users to migrate to API v2 at their earliest convenience.
+
+In addition, both API v1 and API v2 allowed connecting over insecure HTTP
+as opposed to HTTPS. **Beginning in January 2019, we will be redirecting requests over HTTP to HTTPS.**
+This will improve security and allow us to add more security related features to the API going forward.
+For most users, this should be a one line change to connect to the HTTPS version of the API.
+
+.. _API v1: https://docs.readthedocs.io/en/latest/api/v1.html
+
+
+Get in touch
+------------
+
+We are always interested in the amazing things people create when data is openly shared.
+In addition, we are always looking in improve our API to enable more projects and mashups.
+If you use Read the Docs' public API for your project
+or there are additional features you'd like to see in it,
+we would love to `hear from you`_.
+
+.. _hear from you: mailto:team@readthedocs.org

--- a/api-v2.rst
+++ b/api-v2.rst
@@ -11,7 +11,8 @@ Previously, our latest API (v2) was used by our build processes
 but not heavily used by outside users.
 
 As part of this process, we put effort into making sure the API is easy to use
-to access Read the Docs *projects*, *builds*, and *versions*
+to access Read the Docs *projects*, *builds*, and *versions*,
+easier to filter builds and versions by a particular project,
 and that the `documentation`_ is up-to-date.
 
 .. _documentation: https://docs.readthedocs.io/en/latest/api/v2.html


### PR DESCRIPTION
This is fairly simple blog. My goals are twofold:

- Publicly commit to deprecation timelines for things that need to go away like API v1 and HTTP (not HTTPS) access. These deprecation timelines are in our docs but I don't think many people are actively looking for them. This also gives us something to point to when we remove those.
- Solicit feedback on the API and get in touch with people who are using it. This is one of the big problems with no authentication on the API (v1 or v2). We have no real idea who is using it.

I am on the fence about mentioning API v3. I think that changes the tone of the blog and it's odd to be talking about how you just documented API v2 when you're about to replace it.