### PR TITLE
Reformat the blog front page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,23 +1,3 @@
-Welcome
-=======
-
-Welcome to the Read the Docs blog.
-We cover topics related to Read the Docs,
-including:
-
-* Software documentation
-* The Sphinx documentation generator
-* The reStructedText markup language
-
-You can read out posts below.
-If you like them,
-feel free to sign up for our mailing list over on the sidebar.
-
-Latest updates
---------------
-
 .. postlist:: 10
-   :format: {date} - {title}
-
-
-
+    :excerpts:
+    :format: {date} - {title}


### PR DESCRIPTION
Get right to the content on the front page of the blog.
This replaces/updates our index page to get right to the content and hopefully improve the rate people click through into posts.

## BEFORE

<img width="1113" alt="screen shot 2018-10-29 at 12 16 21 pm" src="https://user-images.githubusercontent.com/185043/47674428-7fb41e00-db74-11e8-8eff-e4109e9b70b8.png">

## AFTER

<img width="1097" alt="screen shot 2018-10-29 at 12 16 09 pm" src="https://user-images.githubusercontent.com/185043/47674437-8478d200-db74-11e8-88f1-eec171ee5350.png">
