### PR TITLE
Add a title to the index

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,3 +1,6 @@
+Recent posts
+============
+
 .. postlist:: 10
     :excerpts:
     :format: {date} - {title}


### PR DESCRIPTION
This corrects the title on the blog homepage: `<no title> - Read the Docs Blog` to `Recent posts - Read the Docs Blog`