### PR TITLE
Fix a font issue with the blog

### DIFF
--- a/_themes/rtd-blog/static/main.css
+++ b/_themes/rtd-blog/static/main.css
@@ -256,7 +256,6 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */


### PR DESCRIPTION
Setting `font: inherit` overrides some things that shouldn't be. It's also the default so I'm not sure why it's here. Notably, it disables italics on the entire blog.